### PR TITLE
코드를 최신 버전으로 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 * Pane (Button)
 ---
 ### 환경
-* JDK 8
-* Kotlin 1.5.10
-* Paper 1.16.5
+* JDK 16
+* Kotlin 1.5.20
+* Paper 1.17.1
 ### Gradle
 ```groovy
 allprojects {
@@ -27,7 +27,7 @@ allprojects {
 ```
 ```groovy
 dependencies {
-    implementation 'com.github.monun:invfx:Tag'
+    implementation 'io.github.monun:invfx:Tag'
 }
 ```
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
     kotlin("jvm") version "1.5.20"
     kotlin("plugin.serialization") version "1.5.20"
     id("com.github.johnrengelman.shadow") version "5.2.0"
-    id("org.jetbrains.dokka") version "1.4.32"
     `maven-publish`
-    signing
 }
 java {
     toolchain {
@@ -124,6 +122,16 @@ tasks {
                 it.printStackTrace()
             }
             buildtoolsDir.deleteRecursively()
+        }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>(project.property("pluginName").toString()) {
+            artifactId = project.name
+            from(components["java"])
+            artifact(tasks["sourcesJar"])
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-group=com.github.monun
+group=io.github.monun
 version=2.1.0
 pluginName=InvFX
-pluginMain=com.github.monun.invfx.plugin.InvFXPlugin
+pluginMain=io.github.monun.invfx.plugin.InvFXPlugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server.sh
+++ b/server.sh
@@ -1,32 +1,37 @@
 #!/bin/bash
 
-./gradlew clean debugJar
+#./gradlew clean setupDebugServer
+# To Update Paper:
+# ./gradlew clean setupDebugServer -PupdatePaper
 
-server=paper
-version=1.16.5
 plugins=(
-    'https://github.com/monun/kotlin-plugin/releases/latest/download/Kotlin-1.5.10.jar'
 )
 
 script=$(basename "$0")
 server_folder=".${script%.*}"
 mkdir -p "$server_folder"
 
+server_script="server.sh"
+server_config="server.sh.conf"
+
+if [ ! -f "$server_folder/$server_script" ]; then
+  if [ -f ".server/$server_script" ]; then
+    cp ".server/$server_script" "$server_folder/$server_script"
+  else
+    curl 'https://raw.githubusercontent.com/monun/server-script/master/.server/server.sh' > "$server_folder/server.sh"
+  fi
+fi
+
 cd "$server_folder"
 
-server_script="$server.sh"
-server_config="$server_script.conf"
-wget -qc -N "https://raw.githubusercontent.com/monun/server-script/master/$server_script"
-
-if [ ! -f "$server_config" ]
-then
+if [ ! -f "$server_config" ]; then
     cat << EOF > $server_config
-jar_url="https://papermc.io/api/v1/paper/$version/latest/download"
+server="."
 debug=true
 debug_port=5005
 backup=false
 restart=false
-memory=16
+memory=2
 plugins=(
 EOF
     for plugin in "${plugins[@]}"

--- a/src/main/kotlin/io/github/monun/invfx/InvButton.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvButton.kt
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx
 
-import com.github.monun.invfx.InvRegion
-import org.bukkit.event.inventory.InventoryClickEvent
-import org.bukkit.event.inventory.InventoryOpenEvent
+import org.bukkit.inventory.ItemStack
 
-internal abstract class InvRegionImpl(
-    override val scene: InvSceneImpl,
-    x: Int,
-    y: Int,
-    override val width: Int, override val height: Int
-) : InvNodeImpl(x, y), InvRegion {
-    abstract fun onClick(x: Int, y: Int, event: InventoryClickEvent)
-
-    open fun onOpen(event: InventoryOpenEvent) {}
+/**
+ * [InvPane]에 등록가능한 버튼입니다.
+ */
+interface InvButton : io.github.monun.invfx.InvNode {
+    val pane: io.github.monun.invfx.InvPane
+    var item: ItemStack?
+        get() = pane.getItem(x, y)
+        set(value) = pane.setItem(x, y, value)
 }

--- a/src/main/kotlin/io/github/monun/invfx/InvFX.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvFX.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
-import com.github.monun.invfx.builder.InvSceneBuilder
+import io.github.monun.invfx.builder.InvSceneBuilder
 import org.bukkit.entity.Player
 import org.bukkit.inventory.Inventory
 

--- a/src/main/kotlin/io/github/monun/invfx/InvListView.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvListView.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
 import kotlin.math.max
 

--- a/src/main/kotlin/io/github/monun/invfx/InvNode.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvNode.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
 /**
  *  [InvScene]의 최상위 인터페이스

--- a/src/main/kotlin/io/github/monun/invfx/InvPane.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvPane.kt
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx
 
-internal fun <T> Iterable<T>.forEachInvokeSafety(action: (T) -> Unit) {
-    forEach { it.runCatching(action).onFailure(Throwable::printStackTrace) }
+/**
+ * [InvButton]추가가 가능한 [InvScene]의 구성요소
+ */
+interface InvPane : InvRegion {
+    /**
+     * 등록된 버튼목록입니다.
+     */
+    val buttons: List<io.github.monun.invfx.InvButton>
+
+    /**
+     * 좌표에 등록된 버튼을 가져옵니다.
+     */
+    fun buttonAt(x: Int, y: Int): io.github.monun.invfx.InvButton?
 }

--- a/src/main/kotlin/io/github/monun/invfx/InvRegion.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvRegion.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
 import org.bukkit.inventory.ItemStack
 

--- a/src/main/kotlin/io/github/monun/invfx/InvScene.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvScene.kt
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
-
-import org.bukkit.inventory.ItemStack
+package io.github.monun.invfx
 
 /**
- * [InvPane]에 등록가능한 버튼입니다.
+ * [InvPane]과 [InvListView]로 구성 가능한 [InvWindow]클래스
  */
-interface InvButton : InvNode {
-    val pane: InvPane
-    var item: ItemStack?
-        get() = pane.getItem(x, y)
-        set(value) = pane.setItem(x, y, value)
+interface InvScene : InvWindow {
+    /**
+     * 등록된 [InvRegion] 목록
+     */
+    val regions: List<InvRegion>
+
+    /**
+     * 좌표에 등록된 [InvRegion]을 반환합니다.
+     */
+    fun regionAt(x: Int, y: Int): InvRegion?
 }

--- a/src/main/kotlin/io/github/monun/invfx/InvStage.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvStage.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit

--- a/src/main/kotlin/io/github/monun/invfx/InvWindow.kt
+++ b/src/main/kotlin/io/github/monun/invfx/InvWindow.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx
 
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.inventory.InventoryClickEvent

--- a/src/main/kotlin/io/github/monun/invfx/builder/InvButtonBuilder.kt
+++ b/src/main/kotlin/io/github/monun/invfx/builder/InvButtonBuilder.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.builder
+package io.github.monun.invfx.builder
 
-import com.github.monun.invfx.InvButton
-import com.github.monun.invfx.internal.InvButtonImpl
-import com.github.monun.invfx.internal.InvPaneImpl
+import io.github.monun.invfx.InvButton
+import io.github.monun.invfx.internal.InvButtonImpl
+import io.github.monun.invfx.internal.InvPaneImpl
 import org.bukkit.event.inventory.InventoryClickEvent
 
 /**
@@ -28,9 +28,9 @@ class InvButtonBuilder internal constructor(pane: InvPaneImpl, x: Int, y: Int) {
 
     internal val instance: InvButtonImpl = InvButtonImpl(pane, x, y)
 
-    internal val initActions = ArrayList<(InvButton) -> Unit>(0)
+    internal val initActions = ArrayList<(io.github.monun.invfx.InvButton) -> Unit>(0)
 
-    internal val clickActions = ArrayList<(InvButton, InventoryClickEvent) -> Unit>(0)
+    internal val clickActions = ArrayList<(io.github.monun.invfx.InvButton, InventoryClickEvent) -> Unit>(0)
 
     internal fun build(): InvButtonImpl {
         return instance.apply {
@@ -41,14 +41,14 @@ class InvButtonBuilder internal constructor(pane: InvPaneImpl, x: Int, y: Int) {
     /**
      * [InvButton]이 초기화될 때 호출됩니다.
      */
-    fun onInit(action: (button: InvButton) -> Unit) {
+    fun onInit(action: (button: io.github.monun.invfx.InvButton) -> Unit) {
         initActions += action
     }
 
     /**
      * [org.bukkit.entity.Player]가 [InvButton]을 클릭할 때 호출됩니다.
      */
-    fun onClick(action: (button: InvButton, event: InventoryClickEvent) -> Unit) {
+    fun onClick(action: (button: io.github.monun.invfx.InvButton, event: InventoryClickEvent) -> Unit) {
         clickActions += action
     }
 }

--- a/src/main/kotlin/io/github/monun/invfx/builder/InvListViewBuilder.kt
+++ b/src/main/kotlin/io/github/monun/invfx/builder/InvListViewBuilder.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.builder
+package io.github.monun.invfx.builder
 
-import com.github.monun.invfx.InvListView
-import com.github.monun.invfx.internal.InvListViewImpl
-import com.github.monun.invfx.internal.InvRegionImpl
-import com.github.monun.invfx.internal.InvSceneImpl
+import io.github.monun.invfx.InvListView
+import io.github.monun.invfx.internal.InvListViewImpl
+import io.github.monun.invfx.internal.InvRegionImpl
+import io.github.monun.invfx.internal.InvSceneImpl
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
 import org.bukkit.event.inventory.InventoryClickEvent

--- a/src/main/kotlin/io/github/monun/invfx/builder/InvPaneBuilder.kt
+++ b/src/main/kotlin/io/github/monun/invfx/builder/InvPaneBuilder.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.builder
+package io.github.monun.invfx.builder
 
-import com.github.monun.invfx.InvButton
-import com.github.monun.invfx.InvPane
-import com.github.monun.invfx.internal.InvPaneImpl
-import com.github.monun.invfx.internal.InvSceneImpl
+import io.github.monun.invfx.InvButton
+import io.github.monun.invfx.InvPane
+import io.github.monun.invfx.internal.InvPaneImpl
+import io.github.monun.invfx.internal.InvSceneImpl
 import org.bukkit.event.inventory.InventoryClickEvent
 
 /**
@@ -45,7 +45,7 @@ class InvPaneBuilder internal constructor(scene: InvSceneImpl, x: Int, y: Int, w
     /**
      * [InvButton]을 추가합니다.
      */
-    fun button(x: Int, y: Int, init: (InvButtonBuilder.() -> Unit)? = null): InvButton {
+    fun button(x: Int, y: Int, init: (InvButtonBuilder.() -> Unit)? = null): io.github.monun.invfx.InvButton {
         instance.let {
             require(x in 0 until it.width && y in 0 until it.height) { "Out of range  args=(x=$x y=$y) region=${it.regionString})" }
         }

--- a/src/main/kotlin/io/github/monun/invfx/builder/InvRegionBuilder.kt
+++ b/src/main/kotlin/io/github/monun/invfx/builder/InvRegionBuilder.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.builder
+package io.github.monun.invfx.builder
 
-import com.github.monun.invfx.InvRegion
-import com.github.monun.invfx.internal.InvRegionImpl
+import io.github.monun.invfx.InvRegion
+import io.github.monun.invfx.internal.InvRegionImpl
 
 /**
  * [InvRegion]를 사전설정 할 수 있는 클래스

--- a/src/main/kotlin/io/github/monun/invfx/builder/InvSceneBuilder.kt
+++ b/src/main/kotlin/io/github/monun/invfx/builder/InvSceneBuilder.kt
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.builder
+package io.github.monun.invfx.builder
 
-import com.github.monun.invfx.InvListView
-import com.github.monun.invfx.InvPane
-import com.github.monun.invfx.InvScene
-import com.github.monun.invfx.internal.InvRegionImpl
-import com.github.monun.invfx.internal.InvSceneImpl
+import io.github.monun.invfx.InvListView
+import io.github.monun.invfx.InvPane
+import io.github.monun.invfx.InvScene
+import io.github.monun.invfx.internal.InvRegionImpl
+import io.github.monun.invfx.internal.InvSceneImpl
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryOpenEvent

--- a/src/main/kotlin/io/github/monun/invfx/internal/ActionSupport.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/ActionSupport.kt
@@ -14,19 +14,8 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx.internal
 
-/**
- * [InvPane]과 [InvListView]로 구성 가능한 [InvWindow]클래스
- */
-interface InvScene : InvWindow {
-    /**
-     * 등록된 [InvRegion] 목록
-     */
-    val regions: List<InvRegion>
-
-    /**
-     * 좌표에 등록된 [InvRegion]을 반환합니다.
-     */
-    fun regionAt(x: Int, y: Int): InvRegion?
+internal fun <T> Iterable<T>.forEachInvokeSafety(action: (T) -> Unit) {
+    forEach { it.runCatching(action).onFailure(Throwable::printStackTrace) }
 }

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvButtonImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvButtonImpl.kt
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx.internal
 
-import com.github.monun.invfx.InvButton
-import com.github.monun.invfx.builder.InvButtonBuilder
+import io.github.monun.invfx.InvButton
+import io.github.monun.invfx.builder.InvButtonBuilder
 import com.google.common.collect.ImmutableList
 import org.bukkit.event.inventory.InventoryClickEvent
 
 internal class InvButtonImpl(
     override val pane: InvPaneImpl,
     x: Int, y: Int
-) : InvNodeImpl(x, y), InvButton {
+) : InvNodeImpl(x, y), io.github.monun.invfx.InvButton {
 
-    private lateinit var clickActions: List<(InvButton, InventoryClickEvent) -> Unit>
+    private lateinit var clickActions: List<(io.github.monun.invfx.InvButton, InventoryClickEvent) -> Unit>
 
     fun initialize(builder: InvButtonBuilder) {
         clickActions = ImmutableList.copyOf(builder.clickActions)

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvListViewImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvListViewImpl.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx.internal
 
-import com.github.monun.invfx.InvListView
-import com.github.monun.invfx.builder.InvListViewBuilder
+import io.github.monun.invfx.InvListView
+import io.github.monun.invfx.builder.InvListViewBuilder
 import com.google.common.collect.ImmutableList
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvNodeImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvNodeImpl.kt
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx.internal
 
-import com.github.monun.invfx.InvNode
+import io.github.monun.invfx.InvNode
 
 internal abstract class InvNodeImpl(final override val x: Int, final override val y: Int) : InvNode

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvPaneImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvPaneImpl.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx.internal
 
-import com.github.monun.invfx.InvPane
-import com.github.monun.invfx.builder.InvPaneBuilder
+import io.github.monun.invfx.InvPane
+import io.github.monun.invfx.builder.InvPaneBuilder
 import com.google.common.collect.ImmutableList
 import org.bukkit.event.inventory.InventoryClickEvent
 

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvRegionImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvRegionImpl.kt
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx
+package io.github.monun.invfx.internal
 
-/**
- * [InvButton]추가가 가능한 [InvScene]의 구성요소
- */
-interface InvPane : InvRegion {
-    /**
-     * 등록된 버튼목록입니다.
-     */
-    val buttons: List<InvButton>
+import io.github.monun.invfx.InvRegion
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryOpenEvent
 
-    /**
-     * 좌표에 등록된 버튼을 가져옵니다.
-     */
-    fun buttonAt(x: Int, y: Int): InvButton?
+internal abstract class InvRegionImpl(
+    override val scene: InvSceneImpl,
+    x: Int,
+    y: Int,
+    override val width: Int, override val height: Int
+) : InvNodeImpl(x, y), InvRegion {
+    abstract fun onClick(x: Int, y: Int, event: InventoryClickEvent)
+
+    open fun onOpen(event: InventoryOpenEvent) {}
 }

--- a/src/main/kotlin/io/github/monun/invfx/internal/InvSceneImpl.kt
+++ b/src/main/kotlin/io/github/monun/invfx/internal/InvSceneImpl.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.internal
+package io.github.monun.invfx.internal
 
-import com.github.monun.invfx.InvScene
-import com.github.monun.invfx.InvStage
-import com.github.monun.invfx.builder.InvSceneBuilder
+import io.github.monun.invfx.InvScene
+import io.github.monun.invfx.InvStage
+import io.github.monun.invfx.builder.InvSceneBuilder
 import com.google.common.collect.ImmutableList
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.inventory.InventoryClickEvent

--- a/src/main/kotlin/io/github/monun/invfx/plugin/InvFXPlugin.kt
+++ b/src/main/kotlin/io/github/monun/invfx/plugin/InvFXPlugin.kt
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.plugin
+package io.github.monun.invfx.plugin
 
-import com.github.monun.invfx.InvFX
-import com.github.monun.invfx.openWindow
-import com.github.monun.invfx.window
-import com.github.monun.kommand.kommand
-import com.github.monun.tap.util.updateFromGitHubMagically
+import io.github.monun.invfx.InvFX
+import io.github.monun.invfx.openWindow
+import io.github.monun.invfx.window
+import io.github.monun.kommand.Kommand
+import io.github.monun.kommand.KommandDispatcher
+import io.github.monun.kommand.internal.KommandDispatcherImpl
+import io.github.monun.tap.util.updateFromGitHubMagically
 import kotlinx.coroutines.DelicateCoroutinesApi
 import net.kyori.adventure.text.Component.text
 import org.bukkit.Bukkit
@@ -46,25 +48,23 @@ class InvFXPlugin : JavaPlugin() {
     }
 
     private fun setupCommands() {
-        kommand {
-            register("invfx") {
-                then("version") {
-                    executes { ctxt ->
-                        ctxt.sender.sendMessage("${description.name} ${description.version}")
-                    }
-                }
-                then("update") {
-                    executes {
-                        updateFromGitHubMagically("monun", "invfx", "InvFX.jar", it.sender::sendMessage)
-                    }
-                }
-                then("test") {
-                    require { sender -> sender is Player }
-                    executes {
-                        (it.sender as Player).openWindow(testWindow())
-                    }
+        Kommand.register("invfx") {
+            then("version") {
+                this.executes {
+                    it.source.sender.sendMessage("${description.name} ${description.version}")
                 }
             }
+        }
+        Kommand.register("update") {
+            executes {
+                updateFromGitHubMagically("monun", "invfx", "InvFX.jar", it.source.sender::sendMessage)
+            }
+        }
+        Kommand.register("test") {
+                executes {
+                    require(it.source.sender is Player)
+                    (it.source.sender as Player).openWindow(testWindow())
+                }
         }
     }
 

--- a/src/main/kotlin/io/github/monun/invfx/plugin/InvListener.kt
+++ b/src/main/kotlin/io/github/monun/invfx/plugin/InvListener.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.github.monun.invfx.plugin
+package io.github.monun.invfx.plugin
 
-import com.github.monun.invfx.window
+import io.github.monun.invfx.window
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener

--- a/src/test/kotlin/com/github/noonmaru/BukkitInitialization.kt
+++ b/src/test/kotlin/com/github/noonmaru/BukkitInitialization.kt
@@ -1,16 +1,16 @@
 package com.github.noonmaru
 
-import net.minecraft.server.v1_16_R3.DispenserRegistry
-import net.minecraft.server.v1_16_R3.WorldServer
+import net.minecraft.server.DispenserRegistry
+import net.minecraft.server.level.WorldServer
 import org.apache.commons.lang.reflect.FieldUtils
 import org.apache.logging.log4j.LogManager
 import org.bukkit.Bukkit
 import org.bukkit.Server
 import org.bukkit.World
-import org.bukkit.craftbukkit.v1_16_R3.CraftServer
-import org.bukkit.craftbukkit.v1_16_R3.CraftWorld
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemFactory
-import org.bukkit.craftbukkit.v1_16_R3.util.Versioning
+import org.bukkit.craftbukkit.v1_17_R1.CraftServer
+import org.bukkit.craftbukkit.v1_17_R1.CraftWorld
+import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemFactory
+import org.bukkit.craftbukkit.v1_17_R1.util.Versioning
 import org.mockito.Mockito
 import org.spigotmc.SpigotWorldConfig
 import java.util.logging.Logger


### PR DESCRIPTION
커밋 내역
- gradle을 7.1.1버전으로 업데이트하였습니다.
- 모든 gradle의존성 버전을 업데이트 하였습니다.
- tap과 kommand의 jitpack 제거로 더 이상 필요 없는 jitpack repository를 제거하였습니다.
- 코틀린을 1.5.20으로 업데이트 하였습니다.
- 루트 패키지를 com.github.monun 에서 io.github.monun으로 변경하였습니다.
- Kommand의 업데이트에 따라 플러그인 코드를 변경하였습니다.
- JDK16으로 업데이트 하였습니다.
- Tap repository에서 업데이트 된 파일을 사용하였습니다.
- Readme.md의 의존성 정보를 업데이트 하였습니다.

★ NMS는 모장매핑을 사용하지 **않았습니다**.